### PR TITLE
Add accountcode to CdrScript parameters

### DIFF
--- a/lib/plugins_event_13/cdr.js
+++ b/lib/plugins_event_13/cdr.js
@@ -71,7 +71,8 @@ var astProxy;
               lastapplication: data.lastapplication,
               billableseconds: data.billableseconds,
               destinationcontext: data.destinationcontext,
-              destinationchannel: data.destinationchannel
+              destinationchannel: data.destinationchannel,
+              accountcode: data.accountcode
             });
           }
         } catch (err) {


### PR DESCRIPTION
FIAS cdr uses src field to identify the caller, but it could be setted to trunk number. With this change, also accountcode is sent, and accountcode is setted to the extension.
nethesis/dev#5901